### PR TITLE
service(windows): add support for PreShutdown

### DIFF
--- a/service.go
+++ b/service.go
@@ -203,6 +203,7 @@ func New(i Interface, c *Config) (Service, error) {
 //    - OnFailure               string ("restart" )   - Action to perform on service failure. (restart | reboot | noaction)
 //    - OnFailureDelayDuration  string ( "1s" )       - Delay before restarting the service, time.Duration string.
 //    - OnFailureResetPeriod    int ( 10 )            - Reset period for errors, seconds.
+//    - PreshutdownTimeout      int (0)               - extend the shutdown timeout of the service (in milliseconds)
 type KeyValue map[string]interface{}
 
 // bool returns the value of the given name, assuming the value is a boolean.

--- a/service_windows.go
+++ b/service_windows.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
@@ -179,7 +180,7 @@ func (ws *windowsService) getError() error {
 }
 
 func (ws *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
-	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptPreShutdown
 	changes <- svc.Status{State: svc.StartPending}
 
 	if err := ws.i.Start(ws); err != nil {
@@ -194,6 +195,35 @@ loop:
 		switch c.Cmd {
 		case svc.Interrogate:
 			changes <- c.CurrentStatus
+		case svc.PreShutdown:
+			checkpoint := uint32(1)
+			changes <- svc.Status{State: svc.StopPending, WaitHint: 3000, CheckPoint: checkpoint}
+
+			errCh := make(chan error)
+			go func() {
+				if wsShutdown, ok := ws.i.(Shutdowner); ok {
+					errCh <- wsShutdown.Shutdown(ws)
+				} else {
+					errCh <- ws.i.Stop(ws)
+				}
+			}()
+
+			for {
+				select {
+				case err := <-errCh:
+					if err != nil {
+						ws.setError(err)
+						return true, 2
+					}
+					break loop
+
+				default:
+					time.Sleep(1 * time.Second)
+					checkpoint++
+					changes <- svc.Status{State: svc.StopPending, WaitHint: 3000, CheckPoint: checkpoint}
+				}
+			}
+
 		case svc.Stop:
 			changes <- svc.Status{State: svc.StopPending}
 			if err := ws.i.Stop(ws); err != nil {
@@ -347,6 +377,15 @@ func (ws *windowsService) Install() error {
 			return fmt.Errorf("SetupEventLogSource() failed: %s", err)
 		}
 	}
+
+	// try to extend preshutdown time
+	if timeout := ws.Option.int("PreshutdownTimeout", 0); timeout > 0 {
+		err = windows.ChangeServiceConfig2(s.Handle, windows.SERVICE_CONFIG_PRESHUTDOWN_INFO, (*byte)(unsafe.Pointer(&timeout)))
+		if err != nil {
+			return fmt.Errorf("setting PreshutdownTimeout failed: %s", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add support for the Windows PreShutdown Event plus the PRESHUTDOWN_TIMEOUT.

This will allow your service to persist during shutdown up to 3min to finish it's shutdown operations instead of the default 5sec.

If you set the "PreshutdownTimeout" option, you will be able to extend that 3min timeout to <int>MS.